### PR TITLE
talos 1.5.5 fixes

### DIFF
--- a/pkgs/doall
+++ b/pkgs/doall
@@ -16,6 +16,9 @@ cd build
 
 git apply add_patch_2_of_5.patch
 
+sed -i 's/kconfig-hardened-check/kernel-hardening-checker/g' kernel/build/pkg.yaml
+sed -i 's/kconfig-hardened-check/kernel-hardening-checker/g' kernel/prepare/pkg.yaml
+
 make -j$(nproc) USERNAME=rsmitty PUSH=true PLATFORM=linux/arm64 REGISTRY=127.0.0.1:5000 kernel 
 
 cd ..

--- a/talos/custom_uboot_and_kernel.patch
+++ b/talos/custom_uboot_and_kernel.patch
@@ -8,10 +8,10 @@ index a335112cc..471044879 100644
  
 -FROM ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel
 +#FROM ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel
-+FROM 127.0.0.1:5000/rsmitty/kernel:v1.5.0-9-g7f9d6eb-dirty AS pkg-kernel
++FROM 127.0.0.1:5000/rsmitty/kernel:v1.5.0-dirty AS pkg-kernel
  FROM --platform=amd64 ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel-amd64
 -FROM --platform=arm64 ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel-arm64
-+FROM --platform=arm64 127.0.0.1:5000/rsmitty/kernel:v1.5.0-9-g7f9d6eb-dirty AS pkg-kernel-arm64
++FROM --platform=arm64 127.0.0.1:5000/rsmitty/kernel:v1.5.0-dirty AS pkg-kernel-arm64
 +
 +#FROM --platform=arm64 ghcr.io/siderolabs/u-boot:${PKGS} AS pkg-u-boot-arm64
 +FROM --platform=arm64 127.0.0.1:5000/ubootbash:latest AS pkg-u-boot-arm64

--- a/talos/doall
+++ b/talos/doall
@@ -21,8 +21,8 @@ make -j$(nproc) clean
 
 #make uki-certs
 make -j$(nproc) kernel initramfs PLATFORM=linux/arm64
-make -j$(nproc) installer IMAGE_REGISTRY=127.0.0.1:5000 PUSH=true
-make -j$(nproc) imager IMAGE_REGISTRY=127.0.0.1:5000 PUSH=true
+make -j$(nproc) installer IMAGE_REGISTRY=127.0.0.1:5000 PLATFORM=linux/arm64 PUSH=true
+make -j$(nproc) imager IMAGE_REGISTRY=127.0.0.1:5000 PLATFORM=linux/arm64 PUSH=true
 make -j$(nproc) iso IMAGE_REGISTRY=127.0.0.1:5000 PLATFORM=linux/arm64 PUSH=true 
 make -j$(nproc) sbc-rpi_generic IMAGE_REGISTRY=127.0.0.1:5000 PLATFORM=linux/arm64 PUSH=true
 


### PR DESCRIPTION
- kconfig-hardened-check -> kernel-hardening-checker in pkgs
- remove random suffix from kernel package name
- specify platform during installer and imager stages